### PR TITLE
モンスター検索APIのレスポンスに属性フィールドを追加

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,0 +1,15 @@
+name: migration
+on:
+  workflow_dispatch:
+jobs:
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: migrate DB
+        run: |
+          make migrate-up
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/app/internal/controller/monster/handler.go
+++ b/app/internal/controller/monster/handler.go
@@ -138,7 +138,7 @@ func (m *MonsterHandler) GetAll(c *gin.Context) {
 			Ranking:            ranking,
 			ImageUrl:           pkg.CreateImageURL(r.Id),
 			BGM:                bgm,
-			Element:            r.Element, // Added Element
+			Element:            r.Element,
 		})
 	}
 	response := Monsters{

--- a/app/internal/controller/monster/handler.go
+++ b/app/internal/controller/monster/handler.go
@@ -138,6 +138,7 @@ func (m *MonsterHandler) GetAll(c *gin.Context) {
 			Ranking:            ranking,
 			ImageUrl:           pkg.CreateImageURL(r.Id),
 			BGM:                bgm,
+			Element:            r.Element, // Added Element
 		})
 	}
 	response := Monsters{
@@ -241,6 +242,7 @@ func (m *MonsterHandler) GetById(c *gin.Context) {
 			Ranking:            ranking,
 			ImageUrl:           pkg.CreateImageURL(r.Id),
 			BGM:                bgm,
+			Element:            r.Element, // Added Element
 		}
 	}
 	response := Monster{

--- a/app/internal/controller/monster/response.go
+++ b/app/internal/controller/monster/response.go
@@ -33,6 +33,7 @@ type ResponseJson struct {
 	Ranking            []*Ranking          `json:"ranking,omitempty"`             // 人気投票ランキング
 	ImageUrl           *string             `json:"image_url,omitempty"`           // モンスター画像URL
 	BGM                []*Music            `json:"bgm,omitempty"`                 // BGM
+	Element            string              `json:"element"`                       // モンスターの属性 (changed to string, removed omitempty)
 }
 
 type Weakness_attack struct {

--- a/app/internal/controller/monster/response.go
+++ b/app/internal/controller/monster/response.go
@@ -19,6 +19,7 @@ type ResponseJson struct {
 	Id                 string              `json:"monster_id,omitempty"`          // モンスターID
 	Name               string              `json:"name,omitempty"`                // モンスター名
 	Description        *string             `json:"description,omitempty"`         // モンスターの説明
+	Element            *string             `json:"element,omitempty"`             // モンスターの属性
 	AnotherName        *string             `json:"another_name,omitempty"`        // モンスター別名
 	NameEn             *string             `json:"name_en,omitempty"`             // モンスター名（英語）
 	Location           []*string           `json:"location,omitempty"`            // モンスターの出現場所
@@ -33,7 +34,6 @@ type ResponseJson struct {
 	Ranking            []*Ranking          `json:"ranking,omitempty"`             // 人気投票ランキング
 	ImageUrl           *string             `json:"image_url,omitempty"`           // モンスター画像URL
 	BGM                []*Music            `json:"bgm,omitempty"`                 // BGM
-	Element            string              `json:"element"`                       // モンスターの属性 (changed to string, removed omitempty)
 }
 
 type Weakness_attack struct {

--- a/app/internal/domain/monsters/monster.go
+++ b/app/internal/domain/monsters/monster.go
@@ -8,6 +8,7 @@ type Monster struct {
 	desc        MonsterDesc
 	anotherName MonsterName
 	nameEn      MonsterName
+	Element     string `json:"element"` // THIS IS THE ONLY CHANGE
 }
 
 func newMonster(id MonsterId, name MonsterName, desc MonsterDesc) Monster {

--- a/app/internal/domain/monsters/monster.go
+++ b/app/internal/domain/monsters/monster.go
@@ -8,22 +8,24 @@ type Monster struct {
 	desc        MonsterDesc
 	anotherName MonsterName
 	nameEn      MonsterName
-	Element     string `json:"element"` // THIS IS THE ONLY CHANGE
+	element     MonsterElement
 }
 
-func newMonster(id MonsterId, name MonsterName, desc MonsterDesc) Monster {
+func newMonster(id MonsterId, name MonsterName, desc MonsterDesc, element MonsterElement) Monster {
 	return Monster{
-		id:   id,
-		name: name,
-		desc: desc,
+		id:      id,
+		name:    name,
+		desc:    desc,
+		element: element,
 	}
 }
 
-func NewMonster(id string, name string, desc string) Monster {
+func NewMonster(id string, name string, desc string, element string) Monster {
 	return newMonster(
 		MonsterId{Value: id},
 		MonsterName{Value: name},
 		MonsterDesc{Value: desc},
+		MonsterElement{Value: element},
 	)
 }
 
@@ -45,4 +47,8 @@ func (m *Monster) GetAnotherName() string {
 
 func (m *Monster) GetNameEn() string {
 	return m.nameEn.Value
+}
+
+func (m *Monster) GetElement() string {
+	return m.element.Value
 }

--- a/app/internal/domain/monsters/types.go
+++ b/app/internal/domain/monsters/types.go
@@ -23,3 +23,7 @@ type MonsterCategory struct {
 type GameTitle struct {
 	Value string // 登場したゲームタイトル
 }
+
+type MonsterElement struct {
+	Value string //モンスターの属性
+}

--- a/app/internal/driver/monsters/monsterQueryService.go
+++ b/app/internal/driver/monsters/monsterQueryService.go
@@ -141,6 +141,7 @@ func (s *monsterQueryService) FetchList(ctx context.Context, id string) ([]*mons
 			Weakness_element:   weak_element,
 			Ranking:            ranking,
 			BGM:                bgm,
+			Element:            m.Element,
 		}
 		res = append(res, &r)
 	}

--- a/app/internal/driver/monsters/monsters.go
+++ b/app/internal/driver/monsters/monsters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"mh-api/app/internal/domain/monsters"
 	"mh-api/app/internal/driver/mysql"
+	"mh-api/app/pkg"
 
 	"gorm.io/gorm"
 )
@@ -27,8 +28,8 @@ func (r *monsterRepository) Get(ctx context.Context, monsterId string) (monsters
 
 	res := monsters.Monsters{}
 	for _, r := range monster {
-		domainMonster := monsters.NewMonster(r.MonsterId, r.Name, r.Description)
-		domainMonster.Element = r.Element // Assign Element from db model to domain model
+		element := pkg.PtrToStr(r.Element)
+		domainMonster := monsters.NewMonster(r.MonsterId, r.Name, r.Description, element)
 		res = append(res, domainMonster)
 	}
 
@@ -40,7 +41,7 @@ func (r *monsterRepository) Save(ctx context.Context, m monsters.Monster) error 
 		MonsterId:   m.GetId(),
 		Name:        m.GetName(),
 		Description: m.GetDesc(),
-		Element:     m.Element, // Assign Element from domain model to db model
+		Element:     pkg.StrToPtr(m.GetElement()),
 	}
 	r.conn.Exec("SET foreign_key_checks = 0")
 	err := r.conn.Save(&monster).Error

--- a/app/internal/driver/monsters/monsters.go
+++ b/app/internal/driver/monsters/monsters.go
@@ -27,7 +27,9 @@ func (r *monsterRepository) Get(ctx context.Context, monsterId string) (monsters
 
 	res := monsters.Monsters{}
 	for _, r := range monster {
-		res = append(res, monsters.NewMonster(r.MonsterId, r.Name, r.Description))
+		domainMonster := monsters.NewMonster(r.MonsterId, r.Name, r.Description)
+		domainMonster.Element = r.Element // Assign Element from db model to domain model
+		res = append(res, domainMonster)
 	}
 
 	return res, nil
@@ -38,6 +40,7 @@ func (r *monsterRepository) Save(ctx context.Context, m monsters.Monster) error 
 		MonsterId:   m.GetId(),
 		Name:        m.GetName(),
 		Description: m.GetDesc(),
+		Element:     m.Element, // Assign Element from domain model to db model
 	}
 	r.conn.Exec("SET foreign_key_checks = 0")
 	err := r.conn.Save(&monster).Error

--- a/app/internal/driver/monsters/monsters_test.go
+++ b/app/internal/driver/monsters/monsters_test.go
@@ -39,7 +39,7 @@ func Test_monsterRepository_Save(t *testing.T) {
 	t.Cleanup(mysql.AfetrTest())
 	conn := mysql.New(context.Background())
 
-	saveMonster1 := monsters.NewMonster("0000000004", "ライゼクス", "雷の反逆者")
+	saveMonster1 := monsters.NewMonster("0000000004", "ライゼクス", "雷の反逆者", "雷属性")
 
 	type fields struct {
 		conn *gorm.DB

--- a/app/internal/driver/mysql/schemas.go
+++ b/app/internal/driver/mysql/schemas.go
@@ -7,7 +7,7 @@ type Monster struct {
 	MonsterId   string      `gorm:"column:monster_id;primaryKey;type:varchar(10);not null;index"`
 	Name        string      `gorm:"column:name;type:varchar(255)"`
 	Description string      `gorm:"column:description;type:varchar(255)"`
-	Element     string      `gorm:"column:element;type:varchar(255)"` // Added Element field
+	Element     *string     `gorm:"column:element;type:varchar(255)"`
 	AnotherName string      `gorm:"column:another_name;type:varchar(255)"`
 	NameEn      string      `gorm:"column:name_en;type:varchar(255)"`
 	Weakness    []*Weakness `gorm:"foreignKey:monster_id;references:monster_id"`

--- a/app/internal/driver/mysql/schemas.go
+++ b/app/internal/driver/mysql/schemas.go
@@ -7,6 +7,7 @@ type Monster struct {
 	MonsterId   string      `gorm:"column:monster_id;primaryKey;type:varchar(10);not null;index"`
 	Name        string      `gorm:"column:name;type:varchar(255)"`
 	Description string      `gorm:"column:description;type:varchar(255)"`
+	Element     string      `gorm:"column:element;type:varchar(255)"` // Added Element field
 	AnotherName string      `gorm:"column:another_name;type:varchar(255)"`
 	NameEn      string      `gorm:"column:name_en;type:varchar(255)"`
 	Weakness    []*Weakness `gorm:"foreignKey:monster_id;references:monster_id"`

--- a/app/internal/service/monsters/dto.go
+++ b/app/internal/service/monsters/dto.go
@@ -4,4 +4,5 @@ type MonsterDto struct {
 	ID          string
 	Name        string
 	Description string
+	Element     string
 }

--- a/app/internal/service/monsters/monsters.go
+++ b/app/internal/service/monsters/monsters.go
@@ -27,7 +27,7 @@ func (s *MonsterService) FetchMonsterDetail(ctx context.Context, id string) ([]*
 }
 
 func (s *MonsterService) SaveMonsters(ctx context.Context, param MonsterDto) error {
-	saveData := monsters.NewMonster(param.ID, param.Name, param.Description)
+	saveData := monsters.NewMonster(param.ID, param.Name, param.Description, param.Element)
 	err := s.repo.Save(ctx, saveData)
 	if err != nil {
 		return err

--- a/app/internal/service/monsters/queryService.go
+++ b/app/internal/service/monsters/queryService.go
@@ -17,6 +17,7 @@ type FetchMonsterListDto struct {
 	Description        string             `json:"description,omitempty"`
 	AnotherName        string             `json:"another_name,omitempty"`
 	NameEn             string             `json:"name_en,omitempty"`
+	Element            *string            `json:"element,omitempty"`
 	Location           []string           `json:"location,omitempty"`
 	Category           string             `json:"category,omitempty"`
 	CategoryEnglish    *string            `json:"category_english,omitempty"`

--- a/app/pkg/util.go
+++ b/app/pkg/util.go
@@ -9,6 +9,13 @@ func StrToPtr(s string) *string {
 	return &s
 }
 
+func PtrToStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
 func StrArrayToPtr(s []string) []*string {
 	if len(s) == 0 {
 		return nil

--- a/db/migrations/20250521002025_add_element_to_monsters.sql
+++ b/db/migrations/20250521002025_add_element_to_monsters.sql
@@ -1,0 +1,1 @@
+ALTER TABLE monster ADD COLUMN element VARCHAR(255) NULL;

--- a/db/migrations/20250521002025_add_element_to_monsters.sql
+++ b/db/migrations/20250521002025_add_element_to_monsters.sql
@@ -1,1 +1,5 @@
+-- +migrate Up
 ALTER TABLE monster ADD COLUMN element VARCHAR(255) NULL;
+
+-- +migrate Down
+ALTER TABLE monster DROP COLUMN element;

--- a/db/seed/01_seed.sql
+++ b/db/seed/01_seed.sql
@@ -1,15 +1,15 @@
 -- モンスター
-INSERT INTO monster (monster_id, name, another_name, created_at, updated_at) VALUES 
- (1, "リオレイア", "雌火竜", now(), now()),
- (2, "リオレイア亜種", "桜火竜", now(), now()),
- (3, "リオレイア希少種", "金火竜", now(), now()),
- (4, "紫毒姫リオレイア", "", now(), now()),
- (5, "ヌシ・リオレイア", "雌火竜（二つ名）", now(), now()),
- (6, "リオレウス", "火竜", now(), now()),
- (7, "リオレウス亜種", "蒼火竜", now(), now()),
- (8, "リオレウス希少種", "銀火竜", now(), now()),
- (9, "黒炎王リオレウス", "火竜（二つ名）", now(), now()),
- (10, "ヌシ・リオレウス", "火竜（ヌシ）", now(), now());
+INSERT INTO monster (monster_id, name, element, another_name, created_at, updated_at) VALUES
+ (1, "リオレイア","火", "雌火竜", now(), now()),
+ (2, "リオレイア亜種","火", "桜火竜", now(), now()),
+ (3, "リオレイア希少種","火", "金火竜", now(), now()),
+ (4, "紫毒姫リオレイア", "火", "雌火竜", now(), now()),
+ (5, "ヌシ・リオレイア","火", "雌火竜（二つ名）", now(), now()),
+ (6, "リオレウス", "火","火竜", now(), now()),
+ (7, "リオレウス亜種","火", "蒼火竜", now(), now()),
+ (8, "リオレウス希少種","火", "銀火竜", now(), now()),
+ (9, "黒炎王リオレウス","火", "火竜（二つ名）", now(), now()),
+ (10, "ヌシ・リオレウス","火", "火竜（ヌシ）", now(), now());
  -- 種族
 INSERT INTO tribe (tribe_id, name_ja, name_en, monster_id, created_at, updated_at) VALUES
  (1, "飛竜種", "Flying Wyvern", 1, now(), now()),


### PR DESCRIPTION
close #122 
このコミットは Issue #122 に対応し、モンスター検索APIが各モンスターの属性データを取得・表示できるようにします。

## 実装内容

- 新しいデータベースマイグレーションにより `monster` テーブルに `element` カラムを追加。
- ドメインの `Monster` 構造体に `Element` フィールドを追加。
- データベースモデル `schemas.Monster` (`app/internal/driver/mysql/schemas.go`内) に `Element` フィールドとGORMタグを追加。
- ドライバレイヤー (`app/internal/driver/monsters/monsters.go`内) のデータマッピングロジックを修正し、新しい `Element` フィールドの取得・保存処理に対応。
- コントローラレイヤー (`app/internal/controller/monster/response.go` および `app/internal/controller/monster/handler.go`内) を更新し、APIレスポンスに `Element` フィールドを含めるように変更。
- DTO (`app/internal/service/monsters/queryService.go`内) を更新し、`Element` フィールドを追加。
- ドライバおよびE2Eテスト (`scenario/e2e.yml`内) の関連テストを更新し、`element` フィールドを期待・検証するように変更。

## 動作確認

- レスポンス

```json
{
  "monster": {
    "monster_id": "1",
    "name": "リオレイア",
    "element": "火",
    "category": "飛竜種",
    "title": [
      "MH",
      "MHG",
      "MHP",
      "MH2",
      "P2nd",
      "P2G",
      "P3rd",
      "MH3G",
      "MH3",
      "MH4",
      "MH4G",
      "MHX",
      "MHXX",
      "MHW",
      "MHWI",
      "MHR",
      "MHRS"
    ],
    "ranking": [
      {
        "ranking": "78",
        "vote_year": "2024"
      }
    ],
    "image_url": "https://raw.githubusercontent.com/o-ga09/MH-API/main/data/monster/1.png",
    "bgm": [
      {
        "name": "太古の律動/リオレイア",
        "url": "https://www.youtube.com/watch?v=jLgjOfT_elA"
      }
    ]
  }
}
```
