### PR TITLE
feat: OpenAPI Spec を最新のAPI定義に更新 (#190)

### DIFF
--- a/doc/openapi/swagger.yaml
+++ b/doc/openapi/swagger.yaml
@@ -1,9 +1,93 @@
 basePath: /v1
 definitions:
+  armor.ArmorDetailResponse:
+    properties:
+      defense:
+        type: integer
+      id:
+        type: string
+      name:
+        type: string
+      required:
+        items:
+          $ref: '#/definitions/armor.RequiredItemResponse'
+        type: array
+      resistance:
+        $ref: '#/definitions/armor.ResistanceResponse'
+      skills:
+        items:
+          $ref: '#/definitions/armor.SkillResponse'
+        type: array
+      slot:
+        type: string
+    type: object
+  armor.ErrorResponse:
+    properties:
+      message:
+        type: string
+    type: object
+  armor.ListArmorsResponse:
+    properties:
+      armors:
+        items:
+          $ref: '#/definitions/armor.ArmorDetailResponse'
+        type: array
+    type: object
+  armor.RequiredItemResponse:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
+  armor.ResistanceResponse:
+    properties:
+      dragon:
+        type: integer
+      fire:
+        type: integer
+      ice:
+        type: integer
+      lightning:
+        type: integer
+      water:
+        type: integer
+    type: object
+  armor.SkillResponse:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+    type: object
   item.Item:
     properties:
       item:
         $ref: '#/definitions/item.ResponseJson'
+    type: object
+  item.Items:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/item.ResponseJson'
+        type: array
+      limit:
+        type: integer
+      offset:
+        type: integer
+      total:
+        type: integer
+    type: object
+  item.ItemsByMonster:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/item.Item'
+        type: array
+      monster_id:
+        type: string
+      monster_name:
+        type: string
     type: object
   item.MessageResponse:
     properties:
@@ -67,6 +151,12 @@ definitions:
       category:
         description: モンスターのカテゴリ
         type: string
+      description:
+        description: モンスターの説明
+        type: string
+      element:
+        description: モンスターの属性
+        type: string
       first_weak_attack:
         description: 最有効弱点
         type: string
@@ -86,6 +176,9 @@ definitions:
         type: string
       name:
         description: モンスター名
+        type: string
+      name_en:
+        description: モンスター名（英語）
         type: string
       ranking:
         description: 人気投票ランキング
@@ -136,12 +229,67 @@ definitions:
       water:
         type: string
     type: object
-  weapon.MessageResponse:
+  skill.MessageResponse:
     properties:
       message:
         type: string
     type: object
-  weapon.ResponseJson:
+  skill.ResponseSkill:
+    properties:
+      description:
+        type: string
+      id:
+        type: string
+      level:
+        items:
+          $ref: '#/definitions/skill.ResponseSkillLevel'
+        type: array
+      name:
+        type: string
+    type: object
+  skill.ResponseSkillLevel:
+    additionalProperties:
+      type: string
+    type: object
+  skill.Skill:
+    properties:
+      description:
+        type: string
+      id:
+        type: string
+      level:
+        items:
+          $ref: '#/definitions/skill.ResponseSkillLevel'
+        type: array
+      name:
+        type: string
+    type: object
+  skill.Skills:
+    properties:
+      skills:
+        items:
+          $ref: '#/definitions/skill.ResponseSkill'
+        type: array
+    type: object
+  weapon.ErrorResponse:
+    properties:
+      message:
+        type: string
+    type: object
+  weapon.ListWeaponsResponse:
+    properties:
+      limit:
+        type: integer
+      offset:
+        type: integer
+      total_count:
+        type: integer
+      weapons:
+        items:
+          $ref: '#/definitions/weapon.WeaponDetailResponse'
+        type: array
+    type: object
+  weapon.WeaponDetailResponse:
     properties:
       attack:
         type: string
@@ -149,23 +297,18 @@ definitions:
         type: string
       description:
         type: string
-      elemant_attaxk:
+      element_attack:
         type: string
       image_url:
-        type: string
-      monster_id:
         type: string
       name:
         type: string
       rare:
         type: string
-      shapness:
+      sharpness:
         type: string
-    type: object
-  weapon.Weapon:
-    properties:
-      monster:
-        $ref: '#/definitions/weapon.ResponseJson'
+      weapon_id:
+        type: string
     type: object
 externalDocs:
   description: OpenAPI
@@ -180,32 +323,89 @@ info:
   title: MH-API
   version: v0.1.0
 paths:
-  /items/:itemId:
+  /armors:
+    get:
+      consumes:
+      - application/json
+      description: 全ての防具のリストを返します。
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: 防具のリスト
+          schema:
+            $ref: '#/definitions/armor.ListArmorsResponse'
+        "500":
+          description: サーバ内部エラー
+          schema:
+            $ref: '#/definitions/armor.ErrorResponse'
+      summary: 防具一覧を取得します
+      tags:
+      - Armors
+  /armors/{id}:
+    get:
+      consumes:
+      - application/json
+      description: 指定されたIDの防具の詳細を返します。
+      parameters:
+      - description: 防具ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: 防具の詳細
+          schema:
+            $ref: '#/definitions/armor.ArmorDetailResponse'
+        "400":
+          description: リクエストパラメータが不正な場合
+          schema:
+            $ref: '#/definitions/armor.ErrorResponse'
+        "404":
+          description: 防具が見つからない場合
+          schema:
+            $ref: '#/definitions/armor.ErrorResponse'
+        "500":
+          description: サーバ内部エラー
+          schema:
+            $ref: '#/definitions/armor.ErrorResponse'
+      summary: 防具詳細を取得します
+      tags:
+      - Armors
+  /items:
+    get:
+      description: 全てのアイテム名とIDの一覧を取得する
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/item.Items'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/item.MessageResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/item.MessageResponse'
+      summary: アイテム名の一覧を取得する
+      tags:
+      - アイテム検索
+  /items/{itemId}:
     get:
       consumes:
       - application/json
       description: アイテムを検索して、条件に合致するアイテムを1件取得する
       parameters:
-      - in: query
-        name: item_name
-        type: string
-      - in: query
-        name: item_name_kana
-        type: string
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: monster_id
-        type: string
-      - in: query
-        name: offset
-        type: integer
-      - in: query
-        name: order
-        type: integer
-      - in: query
-        name: sort
+      - description: アイテムID
+        in: path
+        name: itemId
+        required: true
         type: string
       produces:
       - application/json
@@ -229,6 +429,39 @@ paths:
       summary: アイテム検索（1件）
       tags:
       - アイテム検索
+  /items/monsters/{monsterId}:
+    get:
+      consumes:
+      - application/json
+      description: 指定のアイテムが取得可能なモンスターの一覧
+      parameters:
+      - description: モンスターID
+        in: path
+        name: monsterId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/item.ItemsByMonster'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/item.MessageResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/item.MessageResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/item.MessageResponse'
+      summary: アイテム検索（モンスター別）
+      tags:
+      - アイテム検索
   /monsters:
     get:
       consumes:
@@ -242,12 +475,23 @@ paths:
         name: MonsterName
         type: string
       - in: query
+        name: UsageElement
+        type: string
+      - in: query
+        name: WeaknessElement
+        type: string
+      - in: query
+        minimum: 0
         name: limit
         type: integer
       - in: query
+        minimum: 0
         name: offset
         type: integer
-      - in: query
+      - enum:
+        - asc
+        - desc
+        in: query
         name: sort
         type: string
       produces:
@@ -272,7 +516,7 @@ paths:
       summary: モンスター検索（複数件）
       tags:
       - モンスター検索
-  /monsters/:monsterid:
+  /monsters/{id}:
     get:
       consumes:
       - application/json
@@ -281,6 +525,7 @@ paths:
       - description: モンスターID
         in: path
         name: request
+        required: true
         type: string
       produces:
       - application/json
@@ -304,102 +549,108 @@ paths:
       summary: モンスター検索（1件）
       tags:
       - モンスター検索
+  /skills:
+    get:
+      description: 全てのスキルとその情報の一覧を取得する
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/skill.Skills'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/skill.MessageResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/skill.MessageResponse'
+      summary: スキル一覧を取得する
+      tags:
+      - スキル検索
+  /skills/{skillId}:
+    get:
+      consumes:
+      - application/json
+      description: スキルを検索して、条件に合致するスキルを1件取得する
+      parameters:
+      - description: スキルID
+        in: path
+        name: skillId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/skill.Skill'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/skill.MessageResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/skill.MessageResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/skill.MessageResponse'
+      summary: スキル検索（1件）
+      tags:
+      - スキル検索
   /weapons:
     get:
       consumes:
       - application/json
-      description: 武器を検索して、条件に合致する武器を複数件取得する
+      description: 指定されたクエリパラメータに基づいて武器のリストを返します。
       parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: monster_id
+      - description: 武器ID (完全一致)
+        in: query
+        name: weapon_id
         type: string
-      - in: query
+      - description: 武器名 (部分一致を想定)
+        in: query
         name: name
         type: string
-      - in: query
-        name: name_kana
-        type: string
-      - in: query
+      - default: 20
+        description: 取得件数
+        in: query
+        name: limit
+        type: integer
+      - default: 0
+        description: 取得開始位置
+        in: query
         name: offset
         type: integer
-      - in: query
-        name: order
-        type: integer
-      - in: query
+      - description: ソートフィールド (asc/desc)
+        in: query
         name: sort
         type: string
+      - description: ソート順 (0:昇順, 1:降順)
+        in: query
+        name: order
+        type: integer
       produces:
       - application/json
       responses:
         "200":
-          description: OK
+          description: 武器のリストとページネーション情報
           schema:
-            $ref: '#/definitions/weapon.Weapon'
+            $ref: '#/definitions/weapon.ListWeaponsResponse'
         "400":
-          description: Bad Request
+          description: リクエストパラメータが不正な場合
           schema:
-            $ref: '#/definitions/weapon.MessageResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/weapon.MessageResponse'
+            $ref: '#/definitions/weapon.ErrorResponse'
         "500":
-          description: Internal Server Error
+          description: サーバ内部エラー
           schema:
-            $ref: '#/definitions/weapon.MessageResponse'
-      summary: 武器検索（複数件）
+            $ref: '#/definitions/weapon.ErrorResponse'
+      summary: 武器リストを検索します (Gin版)
       tags:
-      - 武器検索
-  /weapons/:bgmid:
-    get:
-      consumes:
-      - application/json
-      description: 武器を検索して、条件に合致する武器を1件取得する
-      parameters:
-      - in: query
-        name: limit
-        type: integer
-      - in: query
-        name: monster_id
-        type: string
-      - in: query
-        name: name
-        type: string
-      - in: query
-        name: name_kana
-        type: string
-      - in: query
-        name: offset
-        type: integer
-      - in: query
-        name: order
-        type: integer
-      - in: query
-        name: sort
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/weapon.Weapon'
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/weapon.MessageResponse'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/weapon.MessageResponse'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/weapon.MessageResponse'
-      summary: 武器検索（1件）
-      tags:
-      - 武器検索
+      - Weapons
 swagger: "2.0"

--- a/internal/controller/armor/handler.go
+++ b/internal/controller/armor/handler.go
@@ -31,7 +31,7 @@ func NewArmorHandler(s IArmorService) *ArmorHandler {
 // @Produce json
 // @Success 200 {object} ListArmorsResponse "防具のリスト"
 // @Failure 500 {object} ErrorResponse "サーバ内部エラー"
-// @Router /skills [get]
+// @Router /armors [get]
 func (h *ArmorHandler) GetAllArmors(c *gin.Context) {
 	appCtx := c.Request.Context()
 
@@ -94,7 +94,7 @@ func (h *ArmorHandler) GetAllArmors(c *gin.Context) {
 // @Failure 400 {object} ErrorResponse "リクエストパラメータが不正な場合"
 // @Failure 404 {object} ErrorResponse "防具が見つからない場合"
 // @Failure 500 {object} ErrorResponse "サーバ内部エラー"
-// @Router /skills/{id} [get]
+// @Router /armors/{id} [get]
 func (h *ArmorHandler) GetArmorByID(c *gin.Context) {
 	appCtx := c.Request.Context()
 

--- a/internal/controller/item/handler.go
+++ b/internal/controller/item/handler.go
@@ -26,7 +26,7 @@ func NewItemHandler(s items.IitemService) *ItemHandler {
 // @Success 200 {object} Items
 // @Failure 400 {object} MessageResponse
 // @Failure 500 {object} MessageResponse
-// @Router /v1/items [get]
+// @Router /items [get]
 func (h *ItemHandler) GetItems(c *gin.Context) {
 	// このエンドポイントではクエリパラメータは必要ないが、将来的にページネーションなどを追加する可能性があるため
 	// バリデーションのフレームワークのみ用意しておく
@@ -49,7 +49,7 @@ func (h *ItemHandler) GetItems(c *gin.Context) {
 // @Failure      400  {object}  MessageResponse
 // @Failure      404  {object}  MessageResponse
 // @Failure      500  {object}  MessageResponse
-// @Router /v1/items/{itemId} [get]
+// @Router /items/{itemId} [get]
 func (h *ItemHandler) GetItem(c *gin.Context) {
 	var req RequestItemByID
 	if err := c.ShouldBindUri(&req); err != nil {
@@ -89,7 +89,7 @@ func (h *ItemHandler) GetItem(c *gin.Context) {
 // @Failure      400  {object}  MessageResponse
 // @Failure      404  {object}  MessageResponse
 // @Failure      500  {object}  MessageResponse
-// @Router /v1/items/monsters/{monsterId} [get]
+// @Router /items/monsters/{monsterId} [get]
 func (h *ItemHandler) GetItemByMonster(c *gin.Context) {
 	// リクエスト構造体にURIパラメータをバインド
 	var req RequestItemByMonster

--- a/internal/controller/monster/handler.go
+++ b/internal/controller/monster/handler.go
@@ -150,12 +150,12 @@ func (m *MonsterHandler) GetAll(c *gin.Context) {
 // @Tags モンスター検索
 // @Accept json
 // @Produce json
-// @Param request path string ture "モンスターID"
+// @Param request path string true "モンスターID"
 // @Success 200 {object} Monster
 // @Failure      400  {object}  MessageResponse
 // @Failure      404  {object}  MessageResponse
 // @Failure      500  {object}  MessageResponse
-// @Router /monsters/:monsterid [get]
+// @Router /monsters/{id} [get]
 func (m *MonsterHandler) GetById(c *gin.Context) {
 	// トレーシング用のスパンを作成（親トランザクションの子スパンとして）
 	ctx := c.Request.Context()

--- a/internal/controller/skill/handler.go
+++ b/internal/controller/skill/handler.go
@@ -28,7 +28,7 @@ func NewSkillHandler(s skills.ISkillService) *SkillHandler {
 // @Success 200 {object} Skills
 // @Failure 400 {object} MessageResponse
 // @Failure 500 {object} MessageResponse
-// @Router /v1/skills [get]
+// @Router /skills [get]
 func (h *SkillHandler) GetSkills(c *gin.Context) {
 	skillsResponse, err := h.service.GetAllSkills(c.Request.Context())
 	if err != nil {
@@ -49,7 +49,7 @@ func (h *SkillHandler) GetSkills(c *gin.Context) {
 // @Failure      400  {object}  MessageResponse
 // @Failure      404  {object}  MessageResponse
 // @Failure      500  {object}  MessageResponse
-// @Router /v1/skills/{skillId} [get]
+// @Router /skills/{skillId} [get]
 func (h *SkillHandler) GetSkill(c *gin.Context) {
 	var req RequestSkillByID
 	if err := c.ShouldBindUri(&req); err != nil {

--- a/internal/controller/weapon/handler.go
+++ b/internal/controller/weapon/handler.go
@@ -26,14 +26,13 @@ func NewWeaponHandler(s IWeaponService) *WeaponHandler {
 // @Tags Weapons
 // @Accept json
 // @Produce json
-// @Param monster_id query string false "武器ID (完全一致)"
+// @Param weapon_id query string false "武器ID (完全一致)"
 // @Param name query string false "武器名 (部分一致を想定)"
-// @Param name_kana query string false "武器名かな (部分一致を想定)"
 // @Param limit query int false "取得件数" default(20)
 // @Param offset query int false "取得開始位置" default(0)
-// @Param sort query string false "ソート対象フィールド (例: attack, rare)"
+// @Param sort query string false "ソートフィールド (asc/desc)"
 // @Param order query int false "ソート順 (0:昇順, 1:降順)"
-// @Success 200 {object} ListWeaponsResponse "武器のリストとページネーション情報" // response.goで定義したListWeaponsResponse
+// @Success 200 {object} ListWeaponsResponse "武器のリストとページネーション情報"
 // @Failure 400 {object} ErrorResponse "リクエストパラメータが不正な場合"
 // @Failure 500 {object} ErrorResponse "サーバ内部エラー"
 // @Router /weapons [get]

--- a/makefile
+++ b/makefile
@@ -1,3 +1,7 @@
+.PHONY: swagger
+swagger:
+	swag init --dir cmd/api,internal/controller/monster,internal/controller/weapon,internal/controller/skill,internal/controller/item,internal/controller/armor --output doc/openapi --outputTypes yaml
+
 .PHONY: lint
 lint:
 	go vet ./...


### PR DESCRIPTION
close #190 

## 変更内容
- `swag init` による自動生成に切り替え（再現性確保）
- 防具API（`/armors`、`/armors/{id}`）を追加
- スキルAPI（`/skills`、`/skills/{skillId}`）を追加
- アイテムAPI（`/items`、`/items/{itemId}`、`/items/monsters/{monsterId}`）を追加
- モンスターAPIに `UsageElement`・`WeaknessElement` クエリパラメータを追加
- モンスター詳細APIのパスパラメータを修正（`:monsterid` → `{id}`）
- 武器APIのパラメータを実装に合わせて修正（`monster_id`→`weapon_id`、存在しない`name_kana`を削除）
- 全レスポンス定義を現行コードに合わせて更新
- `makefile` に `make swagger` ターゲットを追加

## 変更の背景・目的
- Issue #190「OpenAPISpecの更新」への対応
- swagger.yaml が旧来の手動管理で古いまま放置されており、実際のAPIと大きく乖離していたため

## テスト結果
- [x] ユニットテスト実行済み
- [x] `go build ./...` 成功